### PR TITLE
golangci-lintのエラー削除

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -92,7 +92,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-dap v0.2.0/go.mod h1:5q8aYQFnHOAZEMP+6vmq25HKYAEwE+LF5yh7JKrrhSQ=
-github.com/google/subcommands v1.0.1 h1:/eqq+otEXm5vhfBrbREPCSVQbvofip6kIz+mX5TUH7k=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.5.0 h1:I7ELFeVBr3yfPIcc8+MWvrjk+3VjbcSzoXm3JVa+jD8=
@@ -193,7 +192,6 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -252,7 +250,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191127201027-ecd32218bd7f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -1,0 +1,7 @@
+package context
+
+type Key int
+
+const (
+	TransactionKey Key = iota
+)

--- a/repository/transaction_impl.go
+++ b/repository/transaction_impl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/dgraph-io/badger/v3"
+	ctxManager "github.com/mazrean/separated-webshell/pkg/context"
 )
 
 type Transaction struct{}
@@ -14,13 +15,9 @@ func NewTransaction() *Transaction {
 	return &Transaction{}
 }
 
-const (
-	transactionKey = "transaction"
-)
-
 func (*Transaction) Transaction(ctx context.Context, fn func(ctx context.Context) error) error {
 	err := db.Update(func(txn *badger.Txn) error {
-		ctx := context.WithValue(ctx, transactionKey, txn)
+		ctx := context.WithValue(ctx, ctxManager.TransactionKey, txn)
 
 		return fn(ctx)
 	})
@@ -33,7 +30,7 @@ func (*Transaction) Transaction(ctx context.Context, fn func(ctx context.Context
 
 func (*Transaction) RTransaction(ctx context.Context, fn func(ctx context.Context) error) error {
 	err := db.View(func(txn *badger.Txn) error {
-		ctx := context.WithValue(ctx, transactionKey, txn)
+		ctx := context.WithValue(ctx, ctxManager.TransactionKey, txn)
 
 		return fn(ctx)
 	})
@@ -45,7 +42,7 @@ func (*Transaction) RTransaction(ctx context.Context, fn func(ctx context.Contex
 }
 
 func getTransaction(ctx context.Context) (*badger.Txn, error) {
-	iTxn := ctx.Value(transactionKey)
+	iTxn := ctx.Value(ctxManager.TransactionKey)
 	if iTxn == nil {
 		return nil, nil
 	}

--- a/service/pipe.go
+++ b/service/pipe.go
@@ -62,11 +62,14 @@ func (p *Pipe) Pipe(ctx context.Context, userName values.UserName, connection *d
 
 		err = workspace.RemoveConnection()
 		if err != nil {
-			log.Printf("connection num missmatch")
+			log.Printf("connection num missmatch: %+v", err)
 		}
 
 		if workspace.ConnectionNum() == 0 {
-			p.ww.Stop(ctx, workspace)
+			err = p.ww.Stop(ctx, workspace)
+			if err != nil {
+				log.Printf("failed to stop workspace: %+v", err)
+			}
 		}
 	}()
 

--- a/service/pipe.go
+++ b/service/pipe.go
@@ -44,7 +44,11 @@ func (p *Pipe) Pipe(ctx context.Context, userName values.UserName, connection *d
 		}
 	}
 
-	workspace.AddConnection()
+	err = workspace.AddConnection()
+	if err != nil {
+		return fmt.Errorf("failed to add connection: %w", err)
+	}
+
 	workspaceConnection, err := p.wwc.Connect(ctx, workspace)
 	if err != nil {
 		return fmt.Errorf("connect to workspace error: %w", err)

--- a/workspace/docker/docker.go
+++ b/workspace/docker/docker.go
@@ -11,10 +11,10 @@ import (
 )
 
 var (
-	imageRef   string = os.Getenv("IMAGE_URL")
-	imageUser  string = os.Getenv("IMAGE_USER")
-	imageCmd   string = os.Getenv("IMAGE_CMD")
-	cli *client.Client
+	imageRef  string = os.Getenv("IMAGE_URL")
+	imageUser string = os.Getenv("IMAGE_USER")
+	imageCmd  string = os.Getenv("IMAGE_CMD")
+	cli       *client.Client
 )
 
 func Setup() error {

--- a/workspace/docker/docker.go
+++ b/workspace/docker/docker.go
@@ -11,6 +11,9 @@ import (
 )
 
 var (
+	imageRef   string = os.Getenv("IMAGE_URL")
+	imageUser  string = os.Getenv("IMAGE_USER")
+	imageCmd   string = os.Getenv("IMAGE_CMD")
 	cli *client.Client
 )
 

--- a/workspace/docker/workspace.go
+++ b/workspace/docker/workspace.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -14,21 +13,6 @@ import (
 )
 
 var (
-	imageRef   string = os.Getenv("IMAGE_URL")
-	imageUser  string = os.Getenv("IMAGE_USER")
-	imageCmd   string = os.Getenv("IMAGE_CMD")
-	createOpts        = types.ExecConfig{
-		User:         imageUser,
-		WorkingDir:   fmt.Sprintf("/home/%s", imageUser),
-		Cmd:          []string{imageCmd},
-		Tty:          true,
-		AttachStdin:  true,
-		AttachStdout: true,
-		AttachStderr: true,
-	}
-	attachOpts = types.ExecStartCheck{
-		Tty: true,
-	}
 	stopTimeout = 10 * time.Second
 )
 

--- a/workspace/docker/workspace.go
+++ b/workspace/docker/workspace.go
@@ -32,11 +32,6 @@ var (
 	stopTimeout = 10 * time.Second
 )
 
-type containerInfo struct {
-	id         string
-	manageChan chan struct{}
-}
-
 func containerName(userName values.UserName) string {
 	return fmt.Sprintf("user-%s", userName)
 }

--- a/workspace/docker/workspace_connection.go
+++ b/workspace/docker/workspace_connection.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	createOpts        = types.ExecConfig{
+	createOpts = types.ExecConfig{
 		User:         imageUser,
 		WorkingDir:   fmt.Sprintf("/home/%s", imageUser),
 		Cmd:          []string{imageCmd},

--- a/workspace/docker/workspace_connection.go
+++ b/workspace/docker/workspace_connection.go
@@ -5,8 +5,24 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/docker/docker/api/types"
 	"github.com/mazrean/separated-webshell/domain"
 	"github.com/mazrean/separated-webshell/domain/values"
+)
+
+var (
+	createOpts        = types.ExecConfig{
+		User:         imageUser,
+		WorkingDir:   fmt.Sprintf("/home/%s", imageUser),
+		Cmd:          []string{imageCmd},
+		Tty:          true,
+		AttachStdin:  true,
+		AttachStdout: true,
+		AttachStderr: true,
+	}
+	attachOpts = types.ExecStartCheck{
+		Tty: true,
+	}
 )
 
 type WorkspaceConnection struct{}


### PR DESCRIPTION
golangci-lintの導入前のfindingsが残っていたので排除した。